### PR TITLE
feat(navigation): Fix TabIndex Prop On Burger Menu

### DIFF
--- a/packages/bodiless-navigation/src/BurgerMenu/BurgerMenuToggler.tsx
+++ b/packages/bodiless-navigation/src/BurgerMenu/BurgerMenuToggler.tsx
@@ -42,7 +42,7 @@ const TogglerBase: FC<TogglerProps> = ({ components, ...rest }) => {
     <Wrapper>
       <Button
         {...rest}
-        tabindex="0"
+        tabIndex="0"
         role="button"
         onKeyPress={(event: KeyboardEvent) => BurgerMenuKeyPressHandler(event, isVisible, toggle)}
         aria-expanded={!!isVisible}


### PR DESCRIPTION
## Overview
Browser console is triggering error on edit mode due to incorrect prop declaration for tab index on burger menu toggler base.

## Changes
Update "tabindex" to correct "tabIndex".

## Test Instructions
N/A.

## Related Issues
N/A.
