### PR TITLE
bugfix(gatsby-theme): Fix Context Menu Type Import

### DIFF
--- a/packages/bodiless-core/src/Git/useGitButtons.tsx
+++ b/packages/bodiless-core/src/Git/useGitButtons.tsx
@@ -16,7 +16,7 @@
 import React, {
   useState, useEffect, useCallback, useMemo,
 } from 'react';
-import type { TMenuOption } from '../types/ContextMenuTypes';
+import type { TMenuOption } from '../Types/ContextMenuTypes';
 import ContextSubMenu from '../ContextMenu/ContextSubMenu';
 import { useRegisterMenuOptions } from '../PageContextProvider';
 import { contextMenuForm } from '../contextMenuForm';


### PR DESCRIPTION
## Overview
Setup is breaking due to wrong import path of the context menu type on git buttons.

## Changes
Update import path "types/..." to correct "Types/..."
File: https://github.com/wodenx/Bodiless-JS/blob/4feee971d7e4b7d28d0fd5ec28dd1fd70d2b0fc9/packages/bodiless-core/src/Types/ContextMenuTypes.tsx

## Test Instructions
N/A.

## Related Issues
N/A.