### PR TITLE
bugfix(upgrade deps): Fix setup issues on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48958,6 +48958,7 @@
       "devDependencies": {
         "@babel/plugin-proposal-decorators": "^7.4.0",
         "copyfiles": "^2.1.1",
+        "cross-env": "^5.2.0",
         "gatsby-plugin-compile-es6-packages": "^1.1.0",
         "npm-run-all": "^4.1.5",
         "tailwindcss": "^2.0.2",
@@ -50965,6 +50966,7 @@
         "@bodiless/youtube": "^0.3.6",
         "autoprefixer": "^10.0.0",
         "copyfiles": "^2.1.1",
+        "cross-env": "^5.2.0",
         "docsify-cli": "^4.3.0",
         "dotenv": "^8.2.0",
         "express": "^4.17.1",

--- a/sites/test-site/package.json
+++ b/sites/test-site/package.json
@@ -77,7 +77,7 @@
     "build:lib": "bl-clear-logs && gatsby build && bl-validate-logs",
     "build:scripts": "tsc -p ./tsconfig.json",
     "build:search": "npm run search-index",
-    "build:tailwind-configs": "BODILESS_NPM_ROOT='../..' generate-tailwind-configs",
+    "build:tailwind-configs": "cross-env BODILESS_NPM_ROOT='../..' generate-tailwind-configs",
     "check": "tsc -p ./tsconfig.check.json",
     "clean": "rimraf ./public/* ./.cache",
     "dev-backend": "node ./node_modules/@bodiless/backend/src/server.js",
@@ -93,6 +93,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.4.0",
     "copyfiles": "^2.1.1",
+    "cross-env": "^5.2.0",
     "gatsby-plugin-compile-es6-packages": "^1.1.0",
     "npm-run-all": "^4.1.5",
     "tailwindcss": "^2.0.2",


### PR DESCRIPTION
## Overview
Setup on Windows is failing due to the use of env variables on test-site package.json.

## Changes
Add cross-env dep to "devDependencies" and use it on the variable env definition.

## Test Instructions
N/A.

## Related Issues
N/A.