### PR TITLE
bugfix(delete-and-move-redirects): Fix redirect fields on delete and move forms

### DIFF
--- a/packages/bodiless-page/src/Forms/MenuFormFields.tsx
+++ b/packages/bodiless-page/src/Forms/MenuFormFields.tsx
@@ -54,13 +54,14 @@ const PageURLField = (props: FieldProps) => {
   const isFullUrl = isBasePathEmpty;
 
   const {
-    fieldLabel, fieldFull, validate, ...rest
+    fieldLabel, fieldFull, required, validate, ...rest
   } = props;
+
   const {
     fieldState, fieldApi, render, ref, userProps,
   } = useField({
     field: PAGE_URL_FIELD_NAME,
-    validate: getPageUrlValidator(validate),
+    validate: getPageUrlValidator(validate, required),
     placeholder: isFullUrl ? '/mypath/mypage' : 'my-page',
     ...rest,
   });
@@ -149,12 +150,12 @@ const MovePageURLField = (props: FieldProps) => {
   const isBasePathEmpty = isEmptyValue(parentBasePathValue)
   || parentBasePathValue === BASE_PATH_EMPTY_VALUE;
 
-  const { validate, ...rest } = props;
+  const { required, validate, ...rest } = props;
   const {
     fieldState, fieldApi, render, ref, userProps,
   } = useField({
     field: PAGE_URL_FIELD_NAME,
-    validate: getPageUrlValidator(validate),
+    validate: getPageUrlValidator(validate, required),
     placeholder: '/parentpage/thispage',
     ...rest,
   });

--- a/packages/bodiless-page/src/Forms/MenuFormFields.tsx
+++ b/packages/bodiless-page/src/Forms/MenuFormFields.tsx
@@ -54,14 +54,14 @@ const PageURLField = (props: FieldProps) => {
   const isFullUrl = isBasePathEmpty;
 
   const {
-    fieldLabel, fieldFull, required, validate, ...rest
+    fieldLabel, fieldFull, required, simpleValidation, validate, ...rest
   } = props;
 
   const {
     fieldState, fieldApi, render, ref, userProps,
   } = useField({
     field: PAGE_URL_FIELD_NAME,
-    validate: getPageUrlValidator(validate, required),
+    validate: getPageUrlValidator(validate, required, simpleValidation),
     placeholder: isFullUrl ? '/mypath/mypage' : 'my-page',
     ...rest,
   });

--- a/packages/bodiless-page/src/Forms/MenuFormPage.tsx
+++ b/packages/bodiless-page/src/Forms/MenuFormPage.tsx
@@ -40,6 +40,7 @@ const MenuFormPage = (props : PageState) => {
             {FormFields && FormFields(ComponentFormLabelSmall)}
             <PageURLField
               fieldFull
+              required
               validateOnChange
               validateOnBlur
             />

--- a/packages/bodiless-page/src/Forms/MenuFormPageDelete.tsx
+++ b/packages/bodiless-page/src/Forms/MenuFormPageDelete.tsx
@@ -83,6 +83,7 @@ const DeletePageForm = (props : PageState) => {
             <PageURLField
               fieldLabel="Add optional redirect"
               placeholder="/redirectpage"
+              simpleValidation
               validateOnChange
               validateOnBlur
             />

--- a/packages/bodiless-page/src/Forms/MenuFormPageDelete.tsx
+++ b/packages/bodiless-page/src/Forms/MenuFormPageDelete.tsx
@@ -55,12 +55,12 @@ const deletePage = async ({ path, client } : any) => {
 
 const DeletePageForm = (props : PageState) => {
   const {
-    status, errorMessage,
+    status, errorMessage, isRedirectActive,
   } = props;
-
   const defaultUI = usePageMenuOptionUI();
   const {
     ComponentFormDescription,
+    ComponentFormDescriptionEmphasis,
     ComponentFormFieldWrapper,
     ComponentFormLabelBase,
     ComponentFormTitle,
@@ -107,8 +107,14 @@ const DeletePageForm = (props : PageState) => {
             <ComponentFormDescription>
               Upon closing this dialog you will be redirected to the deleted page’s parent page.
             </ComponentFormDescription>
+            {
+              isRedirectActive ? (
+                <ComponentFormDescriptionEmphasis>
+                  Redirect Active
+                </ComponentFormDescriptionEmphasis>
+              ) : null
+            }
           </ContextMenuProvider>
-
         </>
       );
     }
@@ -162,6 +168,7 @@ const menuFormPageDelete = (client: PageClient) => contextMenuForm({
   const [state, setState] = useState<PageState>({
     status: PageStatus.Init,
   });
+  const [isRedirectActive, setRedirectActive] = useState<boolean>(false);
 
   const context = useEditContext();
   const { node } = useNode();
@@ -196,6 +203,7 @@ const menuFormPageDelete = (client: PageClient) => contextMenuForm({
               ? redirectPathInput
               : `/${redirectPathInput}`;
             createRedirect(node, path, redirectPath);
+            setRedirectActive(true);
           }
           actualState = PageStatus.Complete;
           setState({ status: PageStatus.Complete });
@@ -218,6 +226,7 @@ const menuFormPageDelete = (client: PageClient) => contextMenuForm({
       <DeletePageForm
         status={status}
         errorMessage={errorMessage}
+        isRedirectActive={isRedirectActive}
       />
     </>
   );

--- a/packages/bodiless-page/src/Forms/MenuFormPageDelete.tsx
+++ b/packages/bodiless-page/src/Forms/MenuFormPageDelete.tsx
@@ -151,6 +151,7 @@ const menuFormPageDelete = (client: PageClient) => contextMenuForm({
 })(({ formState, formApi } : any) => {
   const { ComponentFormText } = usePageMenuOptionUI();
   const {
+    invalid,
     submits,
     values,
   } = formState;
@@ -181,7 +182,7 @@ const menuFormPageDelete = (client: PageClient) => contextMenuForm({
         });
     }
 
-    if (submits && path) {
+    if (submits && path && !invalid) {
       context.showPageOverlay({ hasSpinner: false });
       actualState = PageStatus.Pending;
       setState({ status: PageStatus.Pending });

--- a/packages/bodiless-page/src/Forms/MenuFormPageMove.tsx
+++ b/packages/bodiless-page/src/Forms/MenuFormPageMove.tsx
@@ -127,7 +127,7 @@ const MovePageComp = (props : PageState) => {
                 initialValue
                 keepState
               />
-              Redirect
+              Add redirect
             </ComponentFormLabel>
           </ContextMenuProvider>
         </>

--- a/packages/bodiless-page/src/Forms/MenuFormPageMove.tsx
+++ b/packages/bodiless-page/src/Forms/MenuFormPageMove.tsx
@@ -118,6 +118,7 @@ const MovePageComp = (props : PageState) => {
             <ComponentFormLabelSmall>Current URL</ComponentFormLabelSmall>
             <ComponentFormDescription>{basePathValue}</ComponentFormDescription>
             <MovePageURLField
+              required
               validateOnChange
               validateOnBlur
             />

--- a/packages/bodiless-page/src/Forms/MenuFormPageNew.tsx
+++ b/packages/bodiless-page/src/Forms/MenuFormPageNew.tsx
@@ -71,7 +71,7 @@ const menuFormPageNew = (client: PageClient) => contextMenuForm({
   const { template } = values;
   const path = getPathValue(values);
   useEffect(() => {
-    // If the form is submitted and valid then lets try to creat a page.
+    // If the form is submitted and valid then lets try to create a page.
     if (submits && path && invalid === false) {
       context.showPageOverlay({ hasSpinner: false });
       setState({ status: PageStatus.Pending });

--- a/packages/bodiless-page/src/MenuOptionUI/usePageMenuOptionUI.ts
+++ b/packages/bodiless-page/src/MenuOptionUI/usePageMenuOptionUI.ts
@@ -27,10 +27,15 @@ import {
 const usePageMenuOptionUI = () => {
   const defaultUI = useMenuOptionUI();
   const {
+    ComponentFormDescription,
     ComponentFormLabel,
-    ComponentFormWarning,
     ComponentFormLink,
+    ComponentFormWarning,
   } = defaultUI;
+
+  const Description = flowHoc(
+    addClasses('bl-italic'),
+  )(ComponentFormDescription as ComponentType<StylableProps>);
 
   const Label = flowHoc(
     removeClasses('bl-text-xs'),
@@ -53,6 +58,7 @@ const usePageMenuOptionUI = () => {
 
   const ui = {
     ...defaultUI,
+    ComponentFormDescriptionEmphasis: Description as ComponentType<HTMLProps<HTMLDivElement>>,
     ComponentFormLabelBase: Label as ComponentType<HTMLProps<HTMLLabelElement>>,
     ComponentFormLabelSmall: LabelSmall as ComponentType<HTMLProps<HTMLLabelElement>>,
     ComponentFormLinkEdit: Link as ComponentType<HTMLProps<HTMLAnchorElement>>,

--- a/packages/bodiless-page/src/constants.ts
+++ b/packages/bodiless-page/src/constants.ts
@@ -16,6 +16,8 @@ const BASE_PATH_EMPTY_VALUE = '/';
 const BASE_PATH_FIELD_NAME = 'basePath';
 const PAGE_URL_FIELD_NAME = 'pagePath';
 const PAGE_URL_INVALID_MESSAGE = 'No special characters, capital letters or spaces allowed, no beginning or ending with - or _';
+const PAGE_URL_NOT_ALLOWED_SPACES = 'No spaces allowed';
+const PAGE_URL_NOT_ALLOWED_EMPTY_FIELD = 'Field can not be empty';
 
 const DEFAULT_PAGE_TEMPLATE = '_default';
 const DEFAULT_PAGE_REDIRECT_STATUS = '301';
@@ -24,17 +26,25 @@ const INPUT_FIELD_DEFAULT_CLASSES = 'bl-text-gray-900 bl-bg-gray-100 bl-text-xs 
 const INPUT_FIELD_INLINE_CLASSES = INPUT_FIELD_DEFAULT_CLASSES.concat(' bl-inline');
 const INPUT_FIELD_BLOCK_CLASSES = INPUT_FIELD_DEFAULT_CLASSES.concat(' bl-block bl-w-full');
 
+const PATTERN_HAS_SPACES = /\s{1,}/;
 const PATTERN_INSENSITIVE_VALID_PATH_URL = /(^\/+|^http|^www)/i;
+const PATTERN_PAGE_PATH = /^[a-z0-9](?:[_-]?[a-z0-9]+)*$/;
+const PATTERN_PAGE_URL = /^[a-z0-9_/-]+$/;
 
 export {
   BASE_PATH_EMPTY_VALUE,
   BASE_PATH_FIELD_NAME,
   PAGE_URL_FIELD_NAME,
   PAGE_URL_INVALID_MESSAGE,
+  PAGE_URL_NOT_ALLOWED_SPACES,
+  PAGE_URL_NOT_ALLOWED_EMPTY_FIELD,
   DEFAULT_PAGE_TEMPLATE,
   DEFAULT_PAGE_REDIRECT_STATUS,
   INPUT_FIELD_DEFAULT_CLASSES,
   INPUT_FIELD_INLINE_CLASSES,
   INPUT_FIELD_BLOCK_CLASSES,
+  PATTERN_HAS_SPACES,
   PATTERN_INSENSITIVE_VALID_PATH_URL,
+  PATTERN_PAGE_PATH,
+  PATTERN_PAGE_URL,
 };

--- a/packages/bodiless-page/src/types.ts
+++ b/packages/bodiless-page/src/types.ts
@@ -58,6 +58,7 @@ type CustomFieldProps = {
   fieldFull?: boolean,
   fieldLabel?: string,
   required?: boolean,
+  simpleValidation?: boolean,
 };
 type FieldProps = Omit<BaseFieldProps, 'field'> & CustomFieldProps;
 type FieldValidate = (value: FormValue, values: FormValues) => FormError;

--- a/packages/bodiless-page/src/types.ts
+++ b/packages/bodiless-page/src/types.ts
@@ -54,11 +54,12 @@ type PageData = {
  * if we decide to allow overriding it in the future
  * then also we need to allow overriding the second PageURLField input
  */
-type FieldLabel = {
+type CustomFieldProps = {
   fieldFull?: boolean,
   fieldLabel?: string,
+  required?: boolean,
 };
-type FieldProps = Omit<BaseFieldProps, 'field'> & FieldLabel;
+type FieldProps = Omit<BaseFieldProps, 'field'> & CustomFieldProps;
 type FieldValidate = (value: FormValue, values: FormValues) => FormError;
 
 export {

--- a/packages/bodiless-page/src/types.ts
+++ b/packages/bodiless-page/src/types.ts
@@ -25,6 +25,7 @@ type PageState = {
   titlePending?: string;
   formTitle?: string,
   linkId?: string,
+  isRedirectActive?: boolean,
   FormFields?: (Label: ComponentType<HTMLProps<HTMLLabelElement>>) => void,
 };
 

--- a/packages/bodiless-page/src/utils.ts
+++ b/packages/bodiless-page/src/utils.ts
@@ -91,15 +91,15 @@ const validatePagePath = (
     : undefined
 );
 
-const getPageUrlValidator = (validate?: FieldValidate) => (
+const getPageUrlValidator = (validate?: FieldValidate, required?: boolean) => (
   value: FormValue, values: FormValues,
-) => validateEmptyField(value)
+) => (required && validateEmptyField(value))
     || validatePageUrl(value)
     || (validate && validate(value, values));
 
-const getPagePathValidator = (validate?: FieldValidate) => (
+const getPagePathValidator = (validate?: FieldValidate, required?: boolean) => (
   value: FormValue, values: FormValues,
-) => validateEmptyField(value)
+) => (required && validateEmptyField(value))
     || validatePagePath(value)
     || (validate && validate(value, values));
 

--- a/packages/bodiless-page/src/utils.ts
+++ b/packages/bodiless-page/src/utils.ts
@@ -27,6 +27,11 @@ import {
   BASE_PATH_FIELD_NAME,
   PAGE_URL_FIELD_NAME,
   PAGE_URL_INVALID_MESSAGE,
+  PAGE_URL_NOT_ALLOWED_EMPTY_FIELD,
+  PAGE_URL_NOT_ALLOWED_SPACES,
+  PATTERN_HAS_SPACES,
+  PATTERN_PAGE_PATH,
+  PATTERN_PAGE_URL,
 } from './constants';
 import type {
   FieldValidate,
@@ -56,18 +61,16 @@ const useBasePathField = () => {
 
 const isEmptyValue = (value : FormValue) => Boolean(value) === false;
 
-const validateEmptyField = (value: FormValue) => (isEmptyValue(value)
-  ? 'Field can not be empty'
-  : undefined
+const validateEmptyField = (value: FormValue) => (
+  isEmptyValue(value) ? PAGE_URL_NOT_ALLOWED_EMPTY_FIELD : undefined
 );
 
-const pagePathReg = /^[a-z0-9](?:[_-]?[a-z0-9]+)*$/;
 const pagePathvalidate = (url: string) => {
   const hasInvalidParts = url.split('/').filter(item => {
     if (item === '') {
       return false;
     }
-    if (!RegExp(pagePathReg).test(item)) {
+    if (!RegExp(PATTERN_PAGE_PATH).test(item)) {
       return true;
     }
     return false;
@@ -78,7 +81,7 @@ const pagePathvalidate = (url: string) => {
 const validatePageUrl = (
   value: FormValue,
 ) => (
-  typeof value === 'string' && (pagePathvalidate(value) || !RegExp(/^[a-z0-9_/-]+$/).test(value))
+  typeof value === 'string' && (pagePathvalidate(value) || !RegExp(PATTERN_PAGE_URL).test(value))
     ? PAGE_URL_INVALID_MESSAGE
     : undefined
 );
@@ -86,22 +89,29 @@ const validatePageUrl = (
 const validatePagePath = (
   value: FormValue,
 ) => (
-  typeof value === 'string' && !RegExp(pagePathReg).test(value)
+  typeof value === 'string' && !RegExp(PATTERN_PAGE_PATH).test(value)
     ? PAGE_URL_INVALID_MESSAGE
     : undefined
 );
 
-const getPageUrlValidator = (validate?: FieldValidate, required?: boolean) => (
-  value: FormValue, values: FormValues,
-) => (required && validateEmptyField(value))
-    || validatePageUrl(value)
-    || (validate && validate(value, values));
+const validatePageSimple = (
+  value: FormValue,
+) => (
+  typeof value === 'string' && RegExp(PATTERN_HAS_SPACES).test(value)
+    ? PAGE_URL_NOT_ALLOWED_SPACES
+    : undefined
+);
 
-const getPagePathValidator = (validate?: FieldValidate, required?: boolean) => (
-  value: FormValue, values: FormValues,
-) => (required && validateEmptyField(value))
-    || validatePagePath(value)
-    || (validate && validate(value, values));
+const getPageUrlValidator = (
+  validate?: FieldValidate,
+  required?: boolean,
+  simpleValidation?: boolean,
+) => (value: FormValue, values: FormValues) => (
+  (required && validateEmptyField(value))
+  || (simpleValidation && validatePageSimple(value))
+  || (!simpleValidation && validatePageUrl(value))
+  || (validate && validate(value, values))
+);
 
 const hasPageChild = async ({ pagePath, client }: any) => {
   const result = await handleBackendResponse(client.directoryChild(pagePath));
@@ -134,7 +144,6 @@ const getPathValue = (values: FormValues) => {
 
 export {
   fieldValueToUrl,
-  getPagePathValidator,
   getPageUrlValidator,
   getPathValue,
   hasPageChild,


### PR DESCRIPTION
## Overview
Fix issues found for redirect on delete/move pages forms:
- "Redirect Active" message is missing on Delete confirmation dialog
- Redirect URL cannot be left blank if something was typed in it and then deleted
- Pressing 'Enter' key triggers 'delete page' process even if there is a validation error for a Redirect URL
- 'New Page URL field' validation rules that's used for 'Optional Redirect URL' differs from the validation rules for Redirect Aliases

## Changes
N/A

## Test Instructions
N/A

## Related Issues
N/A