### PR TITLE
bugfix(move-and-delete-redirects): Fix redirect fields on delete and move forms - Batch 2

### DIFF
--- a/packages/bodiless-page/src/Forms/MenuFormPageDelete.tsx
+++ b/packages/bodiless-page/src/Forms/MenuFormPageDelete.tsx
@@ -43,11 +43,14 @@ const deletePage = async ({ path, client } : any) => {
     if (result.message !== 'Success' && typeof (result.message) === 'string') {
       return Promise.reject(new Error(result.message));
     }
-    try {
-      await handleBackendResponse(client.deleteStaticAssets(path));
-    } catch (e: any) {
-      return Promise.reject(new Error(e.message));
-    }
+    // Deleting the static assets on delete leads to a gatsby image rendering issue.
+    // To be resolved with another approach:
+    // https://github.com/johnsonandjohnson/Bodiless-JS/issues/1348
+    // try {
+    //   await handleBackendResponse(client.deleteStaticAssets(path));
+    // } catch (e: any) {
+    //   return Promise.reject(new Error(e.message));
+    // }
     return Promise.resolve();
   }
   return Promise.reject(new Error('The page cannot be deleted.'));

--- a/packages/bodiless-page/src/Forms/MenuFormPageMove.tsx
+++ b/packages/bodiless-page/src/Forms/MenuFormPageMove.tsx
@@ -93,7 +93,7 @@ const movePage = async ({ origin, destination, client } : any) => {
 
 const MovePageComp = (props : PageState) => {
   const {
-    status, errorMessage,
+    status, errorMessage, isRedirectActive,
   } = props;
   const basePathValue = usePagePath();
 
@@ -101,6 +101,7 @@ const MovePageComp = (props : PageState) => {
   const {
     ComponentFormCheckBox,
     ComponentFormDescription,
+    ComponentFormDescriptionEmphasis,
     ComponentFormLabel,
     ComponentFormLabelSmall,
     ComponentFormTitle,
@@ -149,6 +150,13 @@ const MovePageComp = (props : PageState) => {
             Move operation was successful. Upon closing this dialog you will be redirected to the
             new page’s url.
           </ComponentFormDescription>
+          {
+            isRedirectActive ? (
+              <ComponentFormDescriptionEmphasis>
+                Redirect Active
+              </ComponentFormDescriptionEmphasis>
+            ) : null
+          }
         </>
       );
     case PageStatus.Errored:
@@ -191,6 +199,7 @@ const menuFormPageMove = (client: PageClient) => contextMenuForm({
   const [state, setState] = useState<PageState>({
     status: PageStatus.Init,
   });
+  const [isRedirectActive, setRedirectActive] = useState<boolean>(false);
 
   const context = useEditContext();
   const path = getPathValue(values);
@@ -240,6 +249,7 @@ const menuFormPageMove = (client: PageClient) => contextMenuForm({
           .then(() => {
             if (redirectEnabled) {
               createRedirect(node, originClear, destination);
+              setRedirectActive(true);
             }
             actualState = PageStatus.Complete;
             setState({ status: PageStatus.Complete });
@@ -262,6 +272,7 @@ const menuFormPageMove = (client: PageClient) => contextMenuForm({
       <MovePageComp
         status={status}
         errorMessage={errorMessage}
+        isRedirectActive={isRedirectActive}
       />
     </>
   );


### PR DESCRIPTION
## Overview
Second batch of addressed issues for redirect on delete/move pages forms:
- Apply "Redirect Active" message, previous developed for Delete, to Move form
- Comment out delete static assets operation on delete form since it's leading to issues due to Gatsby (gap: #1348)

## Changes
N/A

## Test Instructions
N/A

## Related Issues
N/A