### PR TITLE
docs: Vital Onboarding doc cleanup

### DIFF
--- a/packages/vital-elements/doc/ExtendingAndComposing.md
+++ b/packages/vital-elements/doc/ExtendingAndComposing.md
@@ -88,7 +88,7 @@ const Custom = asDialogToken({
 });
 ```
 
-Or using th `omit` utility from Lodash:
+Or using the `omit` utility from [Lodash](https://lodash.com/docs/#omit ':target=_blank'):
 
 ```ts
 const Custom = asDialogToken({
@@ -442,3 +442,52 @@ token is really just recomposing it.
 ?> **Note:** The order in which domains are composed is fixed (you can see the full list of domains,
 in order, in [Token Domains](./Tokens/TokenDomains)). It doesn't matter which order you specify them
 in when defining your token; they will always be applied in the canonical order.
+
+## Special Cases
+
+### Removing Components from Fluid Tokens
+
+For some container-like components ([RTE](../VitalEditors/RTE_Editor),
+[chameleons](/Components/Chameleon), [Flow Containers](../VitalFlowContainer), etc.), the selection
+of components is _fluid_ and determined by the tokens — unlike clean components, which define a
+_fixed_ set of components — so removing these components from the token will effectively remove them
+from the container. Note that you must remove them from _all_ domains. The presence of a slot in any
+domain of any token which applies to such component will cause a component of that name to be
+available in the container.
+
+The components can be removed from the token using [Lodash's `omit`
+function](https://lodash.com/docs/#omit ':target=_blank'):
+
+```ts
+const Custom = asFooToken({
+  ...Foo,
+  Layout: {
+    ...omit(Foo.Layout, 'Bar'),
+  },
+  Schema: {
+    ...omit(Foo.Schema, 'Bar'),
+  },
+  Theme: {
+    ...omit(Foo.Theme, 'Bar'),
+  },
+});
+```
+
+In the example above, we're extending the `Foo` token, which utilizes the `Bar` component, and, for
+whatever reason, we've decided we don't want to utilize the `Bar` component in our `Custom` version
+of `Foo`, so, using `omit`, we've removed `Bar` from each domain where it is used.
+
+Looking here—
+
+```ts
+  Layout: {
+    ...omit(Foo.Layout, 'Bar'),
+  },
+```
+
+—we're spreading the `Layout` components — except `Bar` — across the `Layout` domain. We use this
+pattern for the `Schema` and `Theme` domains as well, where `Bar` has also been set.
+
+?> **Note:** For a real-world use case of using `omit` to remove components, see [Removing
+Components from Vital Rich Text Editor by
+Shadowing](../VitalEditors/RichTextCustomizing#removing-components-from-vital-rich-text-editor-by-shadowing).

--- a/packages/vital-elements/doc/GettingStarted/AnatomyOfAToken.md
+++ b/packages/vital-elements/doc/GettingStarted/AnatomyOfAToken.md
@@ -127,5 +127,3 @@ as(withAFalse, WithATrue)(C); // -> <C a={true} />
 It's important to remember that this is also true for the domains of a single token. These are
 applied in a fixed order (see [Token Domains](../Components/VitalElements/Tokens/TokenDomains)), and
 those applied later will take precedence.
-
-[Next: Functional Classes](./FunctionalClasses.md)

--- a/packages/vital-elements/doc/GettingStarted/AnatomyOfAToken.md
+++ b/packages/vital-elements/doc/GettingStarted/AnatomyOfAToken.md
@@ -20,9 +20,9 @@ const Welcome = asDialogToken({
 });
 ```
 
-> Note - so far we are still using the semantic CSS class names from the
-> original React example. In a true Vital token, we would actually use
-> *functional* classes from TailwindCSS. We'll get to that in the next section.
+?> **Note:** So far, we are still using the semantic CSS class names from the original React
+example. In a true Vital token, we would actually use _functional_ classes from Tailwind CSS. We'll
+get to that in the next section.
 
 As we mentioned before, a token is a structured set of higher-order components which can be applied
 to a component. These are structured as a two-layer nested object.

--- a/packages/vital-elements/doc/GettingStarted/ComponentsAndTokens.md
+++ b/packages/vital-elements/doc/GettingStarted/ComponentsAndTokens.md
@@ -30,5 +30,3 @@ multiple components, but they can represent bits of styling at any level. A layo
 or a data binding can all be represented as Vital tokens.
 
 Okay, enough talk. Let's dive into some code to see how these blocks fit together.
-
-[Next: Composing from Outside](./ComposingFromOutside.md)

--- a/packages/vital-elements/doc/GettingStarted/ComponentsAndTokens.md
+++ b/packages/vital-elements/doc/GettingStarted/ComponentsAndTokens.md
@@ -1,38 +1,34 @@
 # Components and Tokens
 
-The basic building blocks of VitalDS are *Components* and *Tokens*.
+The basic building blocks of VitalDS are _Components_ and _Tokens_.
 
 ## Components
 
-Unlike many UI libraries, Vital-DS provides components which are almost always bare
-templates.  They do little or nothing in themselves until one or more _tokens_
-(see below) are applied to them. Compound components expose an API which allows
-tokens to be applied to their constituent elements, or "slots".
+Unlike many UI libraries, VitalDS provides components which are almost always bare templates. They
+do little or nothing in themselves until one or more _tokens_ (see below) are applied to them.
+Compound components expose an API which allows tokens to be applied to their constituent elements,
+or "slots".
 
-Technically, Vital-DS components are plain React functional components wrapped in
-the FClasses `designable` and `stylable` API's which allow them to be acted on
-by tokens.
+Technically, VitalDS components are plain React functional components wrapped in the FClasses
+`designable` and `stylable` APIs, which allow them to be acted on by tokens.
 
 ## Tokens
 
-Vital *tokens* are the meat of VitalDS, where all styling and behavior are
-encapsulated and distributed. They are assembled into libraries, and then
-extended or recomposed by downstream libraries or sites. In almost every case,
-you would not export a styled or otherwise enhanced component from your package;
-instead, you would export a composed token which gives it the look or behavior
-you want.
+Vital _tokens_ are the meat of VitalDS, where all styling and behavior are encapsulated and
+distributed. They are assembled into libraries, and then extended or recomposed by downstream
+libraries or sites. In almost every case, you would not export a styled, or otherwise enhanced,
+component from your package; instead, you would export a composed token which gives it the look or
+behavior you want.
 
-Technically, Vital tokens are expressed as React Higher Order Components (HOCs), or as
-objects which compose several HOCs into a structure which can be more easily
-recomposed or extended.
+Technically, Vital tokens are expressed as React higher-order components (HOCs), or as objects which
+compose several HOCs into a structure which can be more easily recomposed or extended.
 
-> Vital Tokens are an extension of the traditional notion of *Design Tokens*, which
-> usually represent low-level bits of styling like colors, fonts or spacings which
-> can be applied across multiple components.  Like traditional design tokens, vital
-> tokens can be applied across multiple components, but they can represent bits
-> of styling at any level.  A layout, a color scheme or a data binding can all be
-> represented as Vital Tokens.
+?> **Note:** Vital tokens are an extension of the traditional notion of _design tokens_, which
+usually represent low-level bits of styling (like colors, fonts, or spacings) which can be applied
+across multiple components. Like traditional design tokens, Vital tokens can be applied across
+multiple components, but they can represent bits of styling at any level. A layout, a color scheme,
+or a data binding can all be represented as Vital tokens.
 
-Okay, enough talk.  Let's dive into some code to see how these blocks fit together.
+Okay, enough talk. Let's dive into some code to see how these blocks fit together.
 
 [Next: Composing from Outside](./ComposingFromOutside.md)

--- a/packages/vital-elements/doc/GettingStarted/ComposingFromOutside.md
+++ b/packages/vital-elements/doc/GettingStarted/ComposingFromOutside.md
@@ -1,5 +1,25 @@
 # Composing from Outside
 
+<!-- Inlining HTML to add multi-line info block with disclosure widget and unordered list. -->
+<div class="warn">
+  <strong>Note:</strong> Files containing code exampled on this page can be found under the <a
+  target="_blank" rel="noopener noreferrer" href="https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/intro/composing-from-outside">
+  <code>intro/composing-from-outside</code> directory</a> in the <code>vital-examples</code>
+  package.
+  <br><br>
+  <details>
+  <summary>
+    Expand for a list of the most relevant files...
+  </summary>
+
+  - [`./components/Dialog/types.ts`](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/intro/composing-from-outside/components/Dialog/types.ts)
+  - [`./components/Dialog/Dialog.tsx`](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/intro/composing-from-outside/components/Dialog/Dialog.tsx)
+  - [`./components/Dialog/tokens/exampleDialog.ts`](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/intro/composing-from-outside/components/Dialog/tokens/exampleDialog.ts)
+  - [`./components/CustomDialog/tokens/customDialog.ts`](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/intro/composing-from-outside/components/CustomDialog/tokens/customDialog.ts)
+
+  </details>
+</div>
+
 If you're a seasoned React developer, you are familiar with the concept of composition and the
 [standard patterns for using it](https://legacy.reactjs.org/docs/composition-vs-inheritance.html
 ':target=_blank'). You are probably used to composing by creating a new _component_ that assembles

--- a/packages/vital-elements/doc/GettingStarted/ComposingFromOutside.md
+++ b/packages/vital-elements/doc/GettingStarted/ComposingFromOutside.md
@@ -192,5 +192,3 @@ customization.
 Note that the upstream library no longer exports the specialized version of the component
 (`WelcomeDialog`). Instead, it exports the specialization as a token which can be more easily
 extended or customized downstream.
-
-[Next: Reaching Inside](ReachingInside.md)

--- a/packages/vital-elements/doc/GettingStarted/ComposingFromOutside.md
+++ b/packages/vital-elements/doc/GettingStarted/ComposingFromOutside.md
@@ -1,19 +1,18 @@
 # Composing from Outside
 
-If you're a seasoned React developer, you are familiar with the concept of
-composition and the
-[standard patterns for using it](https://legacy.reactjs.org/docs/composition-vs-inheritance.html).
-You are probably used to composing by creating a new *component* which assembles
-and encapsulates the functionality you want to compose. Vital-DS approaches this
-slightly differently. To understand this better, let's look at the
-[Specialization Pattern](https://legacy.reactjs.org/docs/composition-vs-inheritance.html#specialization)
-from the React docs.  Here is the original code rewritten in Typescript.
+If you're a seasoned React developer, you are familiar with the concept of composition and the
+[standard patterns for using it](https://legacy.reactjs.org/docs/composition-vs-inheritance.html
+':target=_blank'). You are probably used to composing by creating a new _component_ that assembles
+and encapsulates the functionality you want to compose. VitalDS approaches this slightly
+differently. To understand this better, let's look at the [Specialization
+Pattern](https://legacy.reactjs.org/docs/composition-vs-inheritance.html#specialization
+':target=_blank') from the React docs. Here is the original code rewritten in TypeScript:
 
 ```ts
 import React from 'react';
 import type { FC } from 'react';
 
-/// FancyBorder........
+// FancyBorder........
 enum FancyBorderColor {
   Red = 'red',
   Blue = 'blue',
@@ -46,7 +45,7 @@ const Dialog: FC<DialogProps> = props => {
       </p>
     </FancyBorder>
   );
-}
+};
 
 const WelcomeDialog: FC = () => (
   <Dialog
@@ -56,12 +55,11 @@ const WelcomeDialog: FC = () => (
 );
 ```
 
-In this example, we take a generic `Dialog` component and create a specific
-variation of it by creating a new `WelcomeDialog` component which supplies
-props. In a sense you could say we are composing *from within* -- the
-composition happens *inside* the new component.
+In this example, we take a generic `Dialog` component and create a specific variation of it by
+creating a new `WelcomeDialog` component that supplies props. In a sense, you could say we are
+composing _from within_ — the composition happens _inside_ the new component.
 
-In Vital, you would accomplish the same thing *from without*, by creating a token:
+In Vital, you would accomplish the same thing _from without_, by creating a token:
 
 ```ts
 import { addProps, as } from '@bodiless/fclasses';
@@ -70,20 +68,20 @@ import { asElementToken } from '@bodiless/vital-elements';
 const Welcome = asElementToken({
   Content: {
     _: addProps({
-        title: 'Welcome',
-        message: 'Thank you for visiting our spacecraft!',
+      title: 'Welcome',
+      message: 'Thank you for visiting our spacecraft!',
     }),
-  }
+  },
 });
 
 const WelcomeDialog = as(Welcome)(Dialog);
 ```
 
-This may take a bit of getting used to, but it opens up a powerful pattern for extension
-and recomposition through *layering*.
+This may take a bit of getting used to, but it opens up a powerful pattern for extension and
+recomposition through _layering_.
 
-Let's imagine that in addition to allowing you to modify the content, the `Dialog`
-component also allowed you to modify the color:
+Let's imagine that in addition to allowing you to modify the content, the `Dialog` component also
+allowed you to modify the color:
 
 ```ts
 
@@ -104,16 +102,17 @@ export const Dialog: FC<DialogProps> = ({ color, title, message })=> (
 );
 
 export const WelcomeDialog: FC = props => (
-    <Dialog
-      color={FancyBorderColor.Blue},
-      title="Welcome"
-      message="Thank you for visiting our spacecraft!" />
+  <Dialog
+    color={FancyBorderColor.Blue},
+    title="Welcome"
+    message="Thank you for visiting our spacecraft!"
+  />
 );
 ```
 
-Now, let's assume these components are provided by an upstream library, and I
-want to use them, but on my site a welcome dialog is red, not blue. I have to
-create a new component, manually replicating the content and changing the color:
+Now, let's assume these components are provided by an upstream library, and you want to use them,
+but on your site, a welcome dialog is red, not blue. You have to create a new component, manually
+replicating the content and changing the color:
 
 ```ts
 const MyWelcomeDialog FC = () => (
@@ -125,7 +124,7 @@ const MyWelcomeDialog FC = () => (
 );
 ```
 
-Now, if the upstream library changes the content:
+Now, if the upstream library changes the content—
 
 ```ts
 const WelcomeDialog: FC = () => (
@@ -137,8 +136,8 @@ const WelcomeDialog: FC = () => (
 );
 ```
 
-I won't receive it. Essentially, I have "forked" the upstream component, and am
-cut off from any future enhancements.
+—you won't receive it. Essentially, you have "forked" the upstream component, and are cut off from
+any future enhancements.
 
 Using tokens, on the other hand, the upstream library can export these specializations
 independently:
@@ -150,8 +149,8 @@ const Welcome = asElementToken({
   },
   Content: {
     _: addProps({
-        title: 'Welcome',
-        message: 'Thank you for visiting our spacecraft!',
+      title: 'Welcome',
+      message: 'Thank you for visiting our spacecraft!',
     }),
   },
 });
@@ -162,12 +161,12 @@ export const exampleDialog = {
 };
 ```
 
-Don't worry too much about the structure of the token--we'll get into that later. For
-now it's enough to know that a token is a structured set of Higher Order Components
-which compose styling or behavior onto a component. In this case, the token uses
-the `addProps` utility to create those Higher Order Components.
+Don't worry too much about the structure of the token — we'll get into that later. For now, it's
+enough to know that a token is a structured set of higher-order components that compose styling or
+behavior onto a component. In this case, the token uses the `addProps` utility to create those
+higher-order components.
 
-Now I can recompose these attributes independently:
+Now you can recompose these attributes independently:
 
 ```ts
 const Welcome = asElementToken({
@@ -184,15 +183,14 @@ const customDialog = {
 const WelcomeDialog = as(customDialog.Welcome)(Dialog);
 ```
 
-This is just plain old Javascript object composition -- we keep all the
-top-level keys of the original token, but supply our own `Theme`.
+This is just plain old JavaScript object composition — you keep all the top-level keys of the
+original token, but supply your own `Theme`.
 
-Now if the content changes upstream, we'll receive the enhancement while still
-retaining our customization.
+Now if the content changes upstream, you'll receive the enhancement while still retaining your
+customization.
 
-Note that the upstream library no longer exports the specialized version
-of the component (`WellcomeDialog`).  Instead it exports the specialization
-as a token which can be more easily extended or customized downstream.
+Note that the upstream library no longer exports the specialized version of the component
+(`WelcomeDialog`). Instead, it exports the specialization as a token which can be more easily
+extended or customized downstream.
 
 [Next: Reaching Inside](ReachingInside.md)
-

--- a/packages/vital-elements/doc/GettingStarted/CoreConcepts.md
+++ b/packages/vital-elements/doc/GettingStarted/CoreConcepts.md
@@ -49,5 +49,3 @@ simplify the process of overriding or extending core styling or behavior. Althou
 different, this is theoretically similar to (and inspired by) [Gatsby Component
 Shadowing](https://www.gatsbyjs.com/blog/2019-04-29-component-shadowing/ ':target=_blank'), so an
 understanding of the principle will help when you come to implementing it in Vital.
-
-[Next: Components and Tokens](./ComponentsAndTokens.md)

--- a/packages/vital-elements/doc/GettingStarted/CoreConcepts.md
+++ b/packages/vital-elements/doc/GettingStarted/CoreConcepts.md
@@ -1,58 +1,53 @@
-# Core Concepts and Pre-requisites
+# Core Concepts and Prerequisites
 
-Vital-DS builds on several key patterns and paradigms from the modern
-front-end ecosystem. You will get further, faster with Vital if you first
-familiarize yourself with these.
+VitalDS builds on several key patterns and paradigms from the modern front-end ecosystem; you will
+make faster progress with Vital by first familiarizing yourself with these.
 
 ## Design Tokens and Atomic Design
 
-These core paradigms from  modern design system thinking define the architecture of
-Vital-DS.  In particular, we build on and extend the notion
-of design tokens to provide reusable and composable bits of styling and
-functionality which can be applied at all levels of the design system, from atoms
-all the way up to pages.
+These core paradigms from modern design system thinking define the architecture of VitalDS. In
+particular, we build on and extend the notion of design tokens to provide reusable and composable
+bits of styling and functionality which can be applied at all levels of the design system, from
+atoms all the way up to pages.
 
-## Utility First CSS
+## Utility-First CSS
 
-Also known as "Atomic" or "Functional" CSS, this is an approach to styling which favors
-composition of small, unambiguous and immutable classes over complex and cascading styles.
-You should have a good understanding of the hows and whys of this approach, and the
-TailwindCSS utility library which adopts it.
+Also known as "Atomic" or "Functional" CSS, this is an approach to styling which favors composition
+of small, unambiguous, and immutable classes over complex and cascading styles. You should have a
+good understanding of the hows and whys of this approach, and the Tailwind CSS utility library which
+adopts it.
 
 ## Functional React
 
-VitalDS is built on React, and makes extensive use of a pattern known as
-*functional composition* using *higher order components*. You should have a good
-understanding of the basic principles of functional programming and how they
-apply in Javascript and React.
+VitalDS is built on React, and makes extensive use of a pattern known as _functional composition_,
+using _higher-order components_ (HOCs). You should have a good understanding of the basic principles
+of functional programming and how they apply in JavaScript and React.
 
-> Note that the modern React world seems to be moving away from higher order components
-> in favor of [hooks](https://legacy.reactjs.org/docs/hooks-intro.html).  We believe
-> this represents an unfortunate shift away from core principles of functional programming
-> ([this article explains why](https://www.robinwieruch.de/react-higher-order-components/)).
-> Libraries like [ad-hok](https://github.com/helixbass/ad-hok) have arisen to try to
-> address this issue, and future versions of VitalDS may adopt a similar paradigm.
+?> **Note:** The modern React world seems to be moving away from higher-order components in favor of
+[hooks](https://legacy.reactjs.org/docs/hooks-intro.html ':target=_blank'). We believe this
+represents an unfortunate shift away from core principles of functional programming ([this article
+explains why](https://www.robinwieruch.de/react-higher-order-components/ ':target=_blank')).
+Libraries like [`ad-hok`](https://github.com/helixbass/ad-hok ':target=_blank') have arisen to try
+to address this issue, and future versions of VitalDS may adopt a similar paradigm.
 
-## Typescript
+## TypeScript
 
-VitalDS is written in Typescript and provides robust typings to help you
-build and use your components and tokens.  While you can use VitalDS in plain Javascript
-the implementation will be much more difficult and error-prone.
+VitalDS is written in TypeScript and provides robust typings to help you build and use your
+components and tokens. While you can use VitalDS in plain JavaScript, the implementation will be
+much more difficult and error-prone.
 
 ## Slots
 
-The *Design API* at the heart of VitalDS is really just a twist on this classic pattern in React and
-many other frontend frameworks. Slots allow you to inject sub-components into a complex
-component.  The Design API allows you to *modify* the sub-components of a complex
-component by applying tokens.
+The _Design API_ at the heart of VitalDS is really just a twist on this classic pattern in React and
+many other front-end frameworks. Slots allow you to inject sub-components into a complex component.
+The Design API allows you to _modify_ the sub-components of a complex component by applying tokens.
 
 ## Shadowing
 
-VitalDS makes use of a technique known as file shadowing to simplify the process
-of overriding or extending core styling or behavior. Although the details are
-different, this is theoretically similar to (and inspired by)
-[Gatsby Component Shadowing](https://www.gatsbyjs.com/blog/2019-04-29-component-shadowing/),
-so an understanding of the principle will help when you come to implementing it
-in Vital.
+VitalDS makes use of a technique known as [file shadowing](/Development/Guides/Shadowing) to
+simplify the process of overriding or extending core styling or behavior. Although the details are
+different, this is theoretically similar to (and inspired by) [Gatsby Component
+Shadowing](https://www.gatsbyjs.com/blog/2019-04-29-component-shadowing/ ':target=_blank'), so an
+understanding of the principle will help when you come to implementing it in Vital.
 
 [Next: Components and Tokens](./ComponentsAndTokens.md)

--- a/packages/vital-elements/doc/GettingStarted/FunctionalClasses.md
+++ b/packages/vital-elements/doc/GettingStarted/FunctionalClasses.md
@@ -1,49 +1,46 @@
 # Functional Classes
 
-Up until now, our ability to control the styling of our `Dialog` through tokens
-has been limited. The component takes a traditional approach to styling,
-applying semantic classes like `Dialog--title` or `Dialog--message` to the
-elements. To modify the styling we need to write our own CSS, overriding
-that provided by the component.  This can rapidly become complicated in
-a large project, where small CSS changes can have unforeseen consequences.
-Paradigms like [CSS Modules]() have arisen to mitigate these risks, but
-they have their own problems when it comes to downstream customization, as
-[this article]() points out.
+Up until now, our ability to control the styling of our `Dialog` through tokens has been limited.
+The component takes a traditional approach to styling, applying semantic classes like
+`Dialog--title` or `Dialog--message` to the elements. To modify the styling we need to write our own
+CSS, overriding that provided by the component. This can rapidly become complicated in a large
+project, where small CSS changes can have unforeseen consequences. Paradigms like [CSS
+Modules](':target=_blank') have arisen to mitigate these risks, but they have their own problems
+when it comes to downstream customization, as [this article](':target=_blank') points out.
 
-Let's see how Vital approaches these issues using the paradigm of "Functional"
-or "Utility First" CSS as embodied in the popular [TailwindCSS library]().
+Let's see how Vital approaches these issues using the paradigm of "Functional" or "Utility-First"
+CSS as embodied in the popular [Tailwind CSS library](https://tailwindcss.com/ ':target=_blank').
 
-> Note - in this example we use default Tailwind color classes. In most cases
-> you will create custom color classes to match your site's design
+?> **Note:** In this example, we use default Tailwind color classes. In most cases, you will create
+custom color classes to match your site's design.
 
 ## Converting the Styles
 
-Functional CSS (sometimes called Atomic or Utility-First) applies a core concept
-from functional programming to CSS classes: every class will have a consistent,
-predetermined effect wherever you apply it.  The effect is usually small and self-
-evident ('text-red-600', 'pl-2', etc).  CSS is generated from a configuration file
-and rarely (if ever) modified.  To apply styling, you attach multiple functional
-classes to the HTML element you want to style.
+Functional CSS (sometimes called Atomic or Utility-First) applies a core concept from functional
+programming to CSS classes: Every class will have a consistent, predetermined effect wherever you
+apply it. The effect is usually small and self-evident (`'text-red-600'`, `'pl-2'`, etc.). CSS is
+generated from a configuration file and rarely (if ever) modified. To apply styling, you attach
+multiple functional classes to the HTML element you want to style.
 
-Let's rewrite our default `Dialog` tokens using Tailwind classes instead of the semantic
-classes from the original example:
+Let's rewrite our default `Dialog` tokens using Tailwind classes instead of the semantic classes
+from the original example:
 
 ```ts
 const Default = asDialogToken({
   Theme: {
     TitleWrapper: 'text-lg font-bold',
     MessageWrapper: 'italic',
-  }
+  },
 });
 ```
 
-We get rid of the `dialog-title` and `dialog-message` classes (and the CSS that goes
-with them), and replace them with functional classes which apply the same styling.
+We get rid of the `dialog-title` and `dialog-message` classes (and the CSS that goes with them), and
+replace them with functional classes which apply the same styling.
 
-A full explanation of the whys and wherefores of this approach is out-of-scope
-of this article. For our purposes, this pattern makes extension with slight
-modificatios in style very easy. For example, our `customDialog.Welcome` could
-surgically override the styling of the title without writing any new CSS:
+A full explanation of the whys and wherefores of this approach is out-of-scope of this article. For
+our purposes, this pattern makes extension with slight modifications in style very easy. For
+example, our `customDialog.Welcome` could surgically override the styling of the title without
+writing any new CSS:
 
 ```ts
 const Welcome = asDialogToken({
@@ -51,37 +48,36 @@ const Welcome = asDialogToken({
   Theme: {
     ...exampleDialog.Welcome.Theme,
     TitleWrapper: 'text-xl font-bold',
-  }
+  },
 });
 ```
 
-This eliminates the need to resort to CSS tricks to override the original CSS
-rules, which can be especially painful if they are scoped (eg via CSS Modules).
+This eliminates the need to resort to CSS tricks to override the original CSS rules, which can be
+especially painful if they are scoped (e.g., via CSS Modules).
 
 ## Element Tokens
 
-So far, we have left the original React example's `FancyBorder` component more-or-less
-intact.  The purpose of this component is to encapsulate decisions about border
-styling so they can be reused across multiple parent components.  In Vital this
-would typically be done with a collection of element tokens.
+So far, we have left the original React example's `FancyBorder` component more-or-less intact. The
+purpose of this component is to encapsulate decisions about border styling so they can be reused
+across multiple parent components. In Vital, this would typically be done with a collection of
+element tokens.
 
-Element tokens represent design tokens in their most common sense--elemental
-bits of styling (colors, spacing, etc) which are reused througout a
-design system.  In other styling paradigmsm they are often represented by
-some sort of CSS variable. In Vital, they are represented like any other
-token, as HOC's which add functional classes.
+Element tokens represent design tokens in their most common sense — elemental bits of styling
+(colors, spacing, etc.) which are reused throughout a design system. In other styling paradigms,
+they are often represented by some sort of CSS variable. In Vital, they are represented like any
+other token: as higher-order components (HOCs) which add functional classes.
 
-> Note in Vital we recognize two levels of design tokens: *palette* tokens,
-> which embody the range of values available for a particular attribute, and
-> "theme" or "semantic" tokens which represent *choices* about how those values
-> should be used in a particular contexxt.  Palette tokens are generally used to
-> define a site's Tailwind configuration, which in turn generates the available
-> functional classes.  Semantic tokens are generally defined in standard Vital
-> token collections.  In this example, we use the default Tailwind palette tokens,
-> and compose them to match our design needs.  In real life, you would likely
-> implement your own palette tokens to match the specific designs of your site.
+?> **Note:** In Vital, we recognize two levels of design tokens: _palette_ tokens, which embody the
+range of values available for a particular attribute; and _theme_ or _semantic_ tokens, which
+represent _choices_ about how those values should be used in a particular context. Palette tokens
+are generally used to define a site's Tailwind configuration, which, in turn, generates the
+available functional classes. Semantic tokens are generally defined in standard Vital token
+collections. In this example, we use the default Tailwind palette tokens, and compose them to match
+our design needs. In real life, you would likely implement your own palette tokens to match the
+specific designs of your site.
 
-Let's replace the `FancyBorder` component with an `exampleBorder` token collection.
+Let's replace the `FancyBorder` component with an `exampleBorder` token collection:
+
 ```ts
 import { asElementToken } from '@bodiless/vital-elements';
 

--- a/packages/vital-elements/doc/GettingStarted/FunctionalClasses.md
+++ b/packages/vital-elements/doc/GettingStarted/FunctionalClasses.md
@@ -140,4 +140,3 @@ const Welcome = asDialogToken({
 
 
 
-[Next: Working with Content](./WorkingWithContent.md)

--- a/packages/vital-elements/doc/GettingStarted/FunctionalClasses.md
+++ b/packages/vital-elements/doc/GettingStarted/FunctionalClasses.md
@@ -1,5 +1,24 @@
 # Functional Classes
 
+<!-- Inlining HTML to add multi-line info block with disclosure widget and unordered list. -->
+<div class="warn">
+  <strong>Note:</strong> Files containing code exampled on this page can be found under the <a
+  target="_blank" rel="noopener noreferrer" href="https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/intro/functional-classes">
+  <code>intro/functional-classes</code> directory</a> in the <code>vital-examples</code> package.
+  <br><br>
+  <details>
+  <summary>
+    Expand for a list of the most relevant files...
+  </summary>
+
+  - [`./components/Dialog/Dialog.tsx`](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/intro/functional-classes/components/Dialog/Dialog.tsx)
+  - [`./components/Dialog/tokens/exampleDialog.ts`](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/intro/functional-classes/components/Dialog/tokens/exampleDialog.ts)
+  - [`./components/CustomDialog/tokens/customDialog.ts`](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/intro/functional-classes/components/CustomDialog/tokens/customDialog.ts)
+  - [`./components/Border/tokens/exampleBorder.ts`](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/intro/functional-classes/components/Border/tokens/exampleBorder.ts)
+
+  </details>
+</div>
+
 Up until now, our ability to control the styling of our `Dialog` through tokens has been limited.
 The component takes a traditional approach to styling, applying semantic classes like
 `Dialog--title` or `Dialog--message` to the elements. To modify the styling we need to write our own

--- a/packages/vital-elements/doc/GettingStarted/README.md
+++ b/packages/vital-elements/doc/GettingStarted/README.md
@@ -1,40 +1,41 @@
-# Introducing Vital-DS
+# Introducing VitalDS
 
-Vital-DS is a white-label component library designed to support flexibility
-and extensibility while still maximizing reuse and maintaining the standards
-that matter most. 
+VitalDS is a white-label component library designed to support flexibility and extensibility while
+still maximizing reuse and maintaining the standards that matter most.
 
-It was created specifically to address the needs of large enterprises supporting
-portfolios of dramatically different brands with widely varying regional
-requirements.
+It was created specifically to address the needs of large enterprises supporting portfolios of
+dramatically different brands with widely varying regional requirements.
 
-The Vital-DS components provide:
+The VitalDS components provide:
 
-- Baked in anlalytics (GA4), SEO, accessibility
-- Out-of-the-box editing with *Bodiless-JS* and an abstract data model which
-  makes it simple to connect components to your own content sources.
-- Cutting edge front-end performance optimizations to keep bundle size down and
-  lighthouse scores up.
-- A modern UI which can be used as-is (with basic theming), extended (with surgical
- precision), or discarded in favor of your own unique designs (while still
- retaining all the goodies described above).
+- Baked in analytics (GA4), SEO, accessibility;
+- Out-of-the-box editing with _BodilessJS_, and an abstract data model which makes it simple to
+  connect components to your own content sources;
+- Cutting-edge front-end performance optimizations to keep bundle size down and Lighthouse scores
+  up;
+- A modern UI which can be used as-is (with basic theming), extended (with surgical precision), or
+  discarded in favor of your own unique designs (while still retaining all the goodies described
+  above).
 
- Vital is built on React and TailwindCSS, and provides starters for both Gatsby and NextJS.
+Vital is built on React and Tailwind CSS, and provides starters for both Gatsby and NextJS.
 
- ## Ready to get started?
+## Ready to Get Started?
 
- The easiest way to get started is to use one of the Bodiless-JS starters:
- ```
- npx @bodiless/cli@next new -r next
- ```
- and choose `__vital_next__` as the template site. For more information, see the
- [Bodiless-JS Getting Started Guide]().
+The easiest way to get started is to use one of the BodilessJS starters—
 
-Once your site is running locally, walk through the introduction in the following
-pages to see how it works.  Or, if you're philosophically minded, read more about
-[why you might want to use it](./WhyVital.md).  Working code for all the eexamples
-in this curriculum can be found in the [vital-examples package]() and is demonstrated
-on the [vital-examples site](). If you like, you can copy these directories to your
-new site and run the examples.
+```shell
+npx @bodiless/cli@next new -r next
+```
+
+—and choose `__vital_next__` as the template site. For more information, see the [BodilessJS
+Getting Started Guide](/About/GettingStarted).
+
+Once your site is running locally, walk through the introduction in the following pages to see how
+it works. Or, if you're philosophically-minded, read more about [why you might want to use
+it](./WhyVital). Working code for all the examples in this curriculum can be found in the
+[`vital-examples` package](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples ':target=_blank')
+and is demonstrated on the
+[`vital-examples` site](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/sites/vital-examples ':target=_blank').
+If you like, you can copy these directories to your new site and run the examples.
 
 [Next: Core Concepts](./CoreConcepts.md)

--- a/packages/vital-elements/doc/GettingStarted/README.md
+++ b/packages/vital-elements/doc/GettingStarted/README.md
@@ -37,5 +37,3 @@ it](./WhyVital). Working code for all the examples in this curriculum can be fou
 and is demonstrated on the
 [`vital-examples` site](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/sites/vital-examples ':target=_blank').
 If you like, you can copy these directories to your new site and run the examples.
-
-[Next: Core Concepts](./CoreConcepts.md)

--- a/packages/vital-elements/doc/GettingStarted/ReachingInside.md
+++ b/packages/vital-elements/doc/GettingStarted/ReachingInside.md
@@ -1,5 +1,24 @@
 # Reaching Inside
 
+<!-- Inlining HTML to add multi-line info block with disclosure widget and unordered list. -->
+<div class="warn">
+  <strong>Note:</strong> Files containing code exampled on this page can be found under the <a
+  target="_blank" rel="noopener noreferrer" href="https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/intro/reaching-inside">
+  <code>intro/reaching-inside</code> directory</a> in the <code>vital-examples</code> package.
+  <br><br>
+  <details>
+  <summary>
+    Expand for a list of the most relevant files...
+  </summary>
+
+  - [`./components/Dialog/types.ts`](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/intro/reaching-inside/components/Dialog/types.ts)
+  - [`./components/Dialog/Dialog.tsx`](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/intro/reaching-inside/components/Dialog/Dialog.tsx)
+  - [`./components/tokens/exampleDialog.ts`](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/intro/reaching-inside/components/tokens/exampleDialog.ts)
+  - [`./components/CustomDialog/tokens/customDialog.ts`](https://github.com/johnsonandjohnson/Bodiless-JS/tree/main/packages/vital-examples/src/intro/reaching-inside/components/CustomDialog/tokens/customDialog.ts)
+
+  </details>
+</div>
+
 The [previous example](./ComposingFromOutside) allowed us to reuse functionality from an upstream
 component library (or, really, _token_ library) while selectively extending it, but it has one
 significant limitation: The various configuration options exposed by the `Dialog` component must be

--- a/packages/vital-elements/doc/GettingStarted/ReachingInside.md
+++ b/packages/vital-elements/doc/GettingStarted/ReachingInside.md
@@ -193,5 +193,3 @@ The possibilities are endless!
 
 ?> **Note:** By convention, tokens which are not intended to be used alone, but rather combined with
 other tokens, are named beginning with `With...`.
-
-[Next: Anatomy Of A Token](./AnatomyOfA_Token)

--- a/packages/vital-elements/doc/GettingStarted/WhyVital.md
+++ b/packages/vital-elements/doc/GettingStarted/WhyVital.md
@@ -1,37 +1,29 @@
 # FClasses and the Vital Design System
 
-This package, and the Vital DS packages which build on it, are designed to solve
-a very specific problem: how to implement a reusable, white-label design system
-in such a way that it can be extended or customized by downstream sites with
-widely different requirements. It is designed to maximize reuse and drive
-standardization, while at the same time allowing differentiation -- without
+This package, and the Vital DS packages which build on it, are designed to solve a very specific
+problem: how to implement a reusable, white-label design system in such a way that it can be
+extended or customized by downstream sites with widely different requirements. It is designed to
+maximize reuse and drive standardization, while at the same time allowing differentiation — without
 dependency on the maintainers of the core system.
 
-Like most modern design frameworks, Vital/FClasses is based on principles of
-atomic design, building up complex structures (pages and templates) out of
-reusable bits. Most such systems focus on the *component* as the unit of design.
-Small components (labels, buttons, icons, etc) are assembled into larger ones
-(cards, accordions, etc), which in turn are composed to form sections and
-eventually whole pages.  This is a powerful compositional model, but it has its
-limitations when it comes to customization.
+Like most modern design frameworks, Vital/FClasses is based on principles of atomic design, building
+up complex structures (pages and templates) out of reusable bits. Most such systems focus on the
+_component_ as the unit of design. Small components (labels, buttons, icons, etc.) are assembled
+into larger ones (cards, accordions, etc.), which, in turn, are composed to form sections and,
+eventually, whole pages. This is a powerful compositional model, but it has its limitations when it
+comes to customization.
 
-Components are "black boxes" - they receive inputs (things like color, size,
-variant) and render differently based on those inputs. This is great as long as
-the variant called for in your design can be produced by manipulating the
-available inputs. But what if you want a variant which can't be produced this
-way? You have two options: you can contact the maintainers of the component adn
-ask them to provide a configuration which produces your variant, or you can fork
-the component and do it yourself.
+Components are "black boxes" — they receive inputs (things like color, size, variant) and render
+differently based on those inputs. This is great as long as the variant called for in your design
+can be produced by manipulating the available inputs. But what if you want a variant which can't be
+produced this way? You have two options: you can contact the maintainers of the component and ask
+them to provide a configuration which produces your variant, or you can fork the component and do it
+yourself.
 
-Both options have disadvantages. In the first case, you are dependent on the core
-team and their priorities.  And over time, as more and more such requests are
-implemented, components become more and more complex, harder to test and maintain.
-On the other hand, the "fork" model means that you are essentially cut off form
-future improvements in the core system.  Bug fixes and enhancements must be manually
-reproduced, and there is no guarantee that your forked component will remain
-compatible with other parts of the system. And, if you are a core maintainer, it means
-that you can no longer roll out globally mandated changes (eg security updates) to
-all your consumers.
-
-
-
+Both options have disadvantages. In the first case, you are dependent on the core team and their
+priorities. And over time, as more and more such requests are implemented, components become more
+and more complex, and harder to test and maintain. On the other hand, the "fork" model means that
+you are essentially cut off from future improvements in the core system. Bug fixes and enhancements
+must be manually reproduced, and there is no guarantee that your forked component will remain
+compatible with other parts of the system. And, if you are a core maintainer, it means that you can
+no longer roll out globally-mandated changes (e.g., security updates) to all your consumers.


### PR DESCRIPTION
## Changes

- Perform doc-cleanup (typos, formatting, etc.) on "Getting Started" section.
- Perform doc-cleanup (typos, formatting, etc.) on "Functional Classes" page.
  - Added as separate commit because page was WIP, and "clean-up" may not yet be desired.
- Remove links for "Next" page at bottom of pages, as Docsify does this automatically.
- Add "Special Cases > Removing Components from Fluid Tokens" section.
  - Moved over from shadowing documentation, as it was really about extending.