### PR TITLE
docs(vital-elements): Domain Usage

### DIFF
--- a/packages/vital-elements/doc/TokenDomains.md
+++ b/packages/vital-elements/doc/TokenDomains.md
@@ -41,8 +41,7 @@ differently as described below.
 The following special domains have values which are not extended domain objects:
 
 - `Compose`: This special domain allows specifying other named tokens which should be composed with
-  this one. See [Extension and Composition](../Tokens/#extension-and-composition) for more
-  details. For example:
+  this one. For example:
 
   ```ts
   const Sticky = asHeaderToken({
@@ -53,6 +52,10 @@ The following special domains have values which are not extended domain objects:
     },
   });
   ```
+
+  - For more details on the `Compose` domains, see:
+    - [Extending and Composing Tokens : The `Compose` Domain](../ExtendingAndComposingTokens#the-compose-domain)
+    - [Vital Tokens : Extension and Composition](./#extension-and-composition)
 
 - `Flow`: By default, the tokens' HOCs for each domain are composed using the Bodiless `asToken`
   utility. This behavior can be overridden by specifying a different composer here. This is useful

--- a/packages/vital-elements/doc/TokenDomains.md
+++ b/packages/vital-elements/doc/TokenDomains.md
@@ -153,8 +153,8 @@ const Example = asLinkToken({
 
 ## How to Determine the Appropriate Domain for a Utility Class
 
-Whenever you create a utility class, you'll need to determine the appropriate domain in which it
-should be placed. The Tailwind documentation is a useful aid in this regard. Visit the [Tailwind
+Whenever you use a utility class, you'll need to determine the appropriate domain in which it should
+be placed. The Tailwind documentation is a useful aid in this regard. Visit the [Tailwind
 Documentation](https://tailwindcss.com/docs/installation ':target=_blank'), and take note of the
 table of contents listed in the left sidebar. Using this table of contents, identify the category to
 which the utility class you've written belongs. Then, using the table below, find the associated

--- a/packages/vital-elements/doc/TokenDomains.md
+++ b/packages/vital-elements/doc/TokenDomains.md
@@ -24,7 +24,6 @@ differently as described below.
   line-spacing, etc.
 - `Theme`: Tokens which apply styling which is very likely to be overridden; e.g., colors,
   typography, sizing such as `width` and `height`, etc. 
-- `Editors`: Tokens which define how a component's data are edited.
 - `Content`: Tokens which provide default content or other fixed props. Any hardcoded, translatable
   strings belong in this domain.
 - `Behavior`: Tokens which define or add behaviors to a component; e.g., the expanding and
@@ -146,8 +145,8 @@ const Example = asLinkToken({
 
 ### Access to Component Data
 
-Note the position of the `Editors` and `Schema` domains which usually provide the data that a
-component renders. They are applied "outside" (after) the styling domains (`Theme`, `Layout`,
-`Spacing`), so that these domains will have access to the data (to allow conditional styling based
-on state). However, they are "inside" (before) the `Compose` and `Condition` domain — so that tokens
-added to the component via `Compose` will not have access to the component's data.
+Note the position of the `Schema` domain, which usually provides the data that a component renders.
+It's applied "outside" (after) the styling domains (`Theme`, `Layout`, `Spacing`), so that these
+domains will have access to the data (to allow conditional styling based on state). However, it's
+"inside" (before) the `Compose` and `Condition` domain — so that tokens added to the component via
+`Compose` will not have access to the component's data.

--- a/packages/vital-elements/doc/TokenDomains.md
+++ b/packages/vital-elements/doc/TokenDomains.md
@@ -1,8 +1,8 @@
 # Token Domains
 
-Vital tokens are expressed in a special format known as the _Token Object Notation_. The keys of
-this object are "domains" — special groupings of designs or HOCs which can be overridden or extended
-separately by downstream consumers.
+Vital tokens are expressed in a special format known as the [_Token Object
+Notation_](./#token-object-notation). The keys of this object are "domains" — special groupings of
+designs or HOCs which can be overridden or extended separately by downstream consumers.
 
 A downside of using Tailwind is that it can result in long lists of classes in your HTML that are
 difficult to parse through. Using domains allows you to separate these long lists of classes into
@@ -29,7 +29,7 @@ differently as described below.
 - `Spacing`: Tokens which sit somewhere between `Theme` and `Layout`; e.g., padding, margin,
   line-spacing, etc.
 - `Theme`: Tokens which apply styling which is very likely to be overridden; e.g., colors,
-  typography, sizing such as `width` and `height`, etc. 
+  typography, sizing such as `width` and `height`, etc.
 - `Content`: Tokens which provide default content or other fixed props. Any hardcoded, translatable
   strings belong in this domain.
 - `Behavior`: Tokens which define or add behaviors to a component; e.g., the expanding and
@@ -81,8 +81,9 @@ The following special domains have values which are not extended domain objects:
 
 ## Order of Domains
 
-HOCs defined for each domain are applied in a fixed order (as listed above), regardless of the order
-in which they are specified in an individual token.
+HOCs defined for each domain are applied in a fixed order (as listed above). Regardless of the order
+in which domains are specified in an individual token, they will always be applied in the canonical
+order.
 
 For example, given:
 
@@ -172,6 +173,28 @@ domain.
 | Interactivity     | Behavior |
 | SVG               | Theme    |
 | Accessibility     | Behavior |
+
+## Compose vs Extend vs Override
+
+As mentioned, domains can be _extended_ or _overridden_. An extension or override can be made at the
+token, domain, or slot (component) level. _Extending_ is useful when you only need to make a small
+number of changes to a token/domain/slot. _Overriding_ allows you to completely overwrite a
+token/domain/slot, essentially writing your own version of it from scratch. This is useful when you
+need to make many adjustments to a token/domain/slot, and extending it would take more effort than
+simply rewriting it.
+
+Similar to extension is _composition_. Where extension takes an existing token and modifies its
+effect, composition takes several existing tokens and combines them. Use _composition_ when you are
+adding styling or behavior that creates a variation of the original component that downstream
+consumers may choose to add, remove, customize, or combine with other variations. Use _extension_
+when you are customizing an existing token at the brand or site level, and, especially, when you
+want to completely override one or more domains from the original token (as this isn't possible with
+composition).
+
+For further details on composing, extending, and overriding, please see:
+
+- [Extending and Composing Tokens](../ExtendingAndComposingTokens)
+- [Vital Tokens : Extension and Composition](./#extension-and-composition)
 
 ## Additional Considerations and Gotchas
 

--- a/packages/vital-elements/doc/TokenDomains.md
+++ b/packages/vital-elements/doc/TokenDomains.md
@@ -4,6 +4,12 @@ Vital tokens are expressed in a special format known as the _Token Object Notati
 this object are "domains" — special groupings of designs or HOCs which can be overridden or extended
 separately by downstream consumers.
 
+A downside of using Tailwind is that it can result in long lists of classes in your HTML that are
+difficult to parse through. Using domains allows you to separate these long lists of classes into
+groups of shorter lists. This can be especially helpful if you have a bug in a particular domain
+(e.g., `Layout`), as you can focus your debugging attention on that domain and the set of tokens
+within it.
+
 ## Allowed Domains
 
 The set of allowed domains is defined by Vital as follows. For most domains, the value is an
@@ -140,6 +146,32 @@ const Example = asLinkToken({
   },
 });
 ```
+
+## How to Determine the Appropriate Domain for a Utility Class
+
+Whenever you create a utility class, you'll need to determine the appropriate domain in which it
+should be placed. The Tailwind documentation is a useful aid in this regard. Visit the [Tailwind
+Documentation](https://tailwindcss.com/docs/installation ':target=_blank'), and take note of the
+table of contents listed in the left sidebar. Using this table of contents, identify the category to
+which the utility class you've written belongs. Then, using the table below, find the associated
+domain.
+
+| Tailwind Category | Domain   |
+| ----------------- | -------- |
+| Layout            | Layout   |
+| Flexbox & Grid    | Layout   |
+| Spacing           | Spacing  |
+| Sizing            | Theme    |
+| Typography        | Theme    |
+| Borders           | Theme    |
+| Effects           | Theme    |
+| Filter            | Theme    |
+| Tables            | Theme    |
+| Transitions       | Behavior |
+| Transforms        | Behavior |
+| Interactivity     | Behavior |
+| SVG               | Theme    |
+| Accessibility     | Behavior |
 
 ## Additional Considerations and Gotchas
 

--- a/packages/vital-elements/doc/Tokens.md
+++ b/packages/vital-elements/doc/Tokens.md
@@ -298,14 +298,14 @@ export const brandLink = {
 };
 ```
 
-Here we define two "domains" — `Theme` and `Editors` — and specify element-level tokens which should
+Here we define two "domains" — `Theme` and `Schema` — and specify element-level tokens which should
 be applied to the `Wrapper` key of the designable `Link` component.
 
 Note that we reuse element-level tokens (`brandElement.TextLink` and `brandElement.EditableLink`).
 These are defined at the element level because there may be times when you wish to apply that
 styling or behavior to a plain `A` tag.
 
-?> **Note:** Note also the use of the special `_` key in the `Editors` domain. This indicates that
+?> **Note:** Note also the use of the special `_` key in the `Schema` domain. This indicates that
 the associated HOC(s) should be applied to the component as a whole rather than to an individual
 design element within the component.
 
@@ -347,12 +347,12 @@ import omit from 'lodash/omit';
 import { LinkClean } from '@bodiless/vital-link';
 import { brandLink } from '@bodiless/brand';
 
-const NonEditableLink = as(omit(brandLink.Default, 'Editors'))(LinkClean);
+const NonEditableLink = as(omit(brandLink.Default, 'Schema'))(LinkClean);
 ```
 
 #### Domains
 
-In the above example, we defined two _domains_: `Theme` and `Editors`. This choice was based on an
+In the above example, we defined two _domains_: `Theme` and `Schema`. This choice was based on an
 understanding of how the token would likely be reused or extended by downstream consumers. In this
 case, we separated design elements which were very unlikely to be reused (typography and colors),
 from a behavior (editability) which was more likely to be reused, but which might also be extracted.

--- a/packages/vital-elements/doc/Tokens.md
+++ b/packages/vital-elements/doc/Tokens.md
@@ -335,8 +335,8 @@ export const siteLink = {
 };
 ```
 
-Our site-level `Default` token reuses everything from the Vital `Default` token, but overrides the `Theme`
-domain with site-specific styling.
+Our site-level `Default` token reuses everything from the Vital `Default` token, but overrides the
+`Theme` domain with site-specific styling.
 
 As another example, imagine we wanted to reuse the styling of the original link, but in a context
 where we did not want the link to be editable by a Content Editor. We could easily define our


### PR DESCRIPTION
## Changes

Update "Token Domains" documentation.

- Remove `Editors` domain from "Token Domains" page.
  - Replace `Editors` domain with `Schema` on "Vital Tokens" page.
- Add section on "How to Determine the Appropriate Domain for a Utility Class."
- Add "Compose vs Extend vs Override" section.
- Add link to "The `Compose` Domain" section.

## Related Issues

Fixes [#2101](https://github.com/johnsonandjohnson/Bodiless-JS/issues/2101)